### PR TITLE
docs: Note attributes in docstring

### DIFF
--- a/party/party.py
+++ b/party/party.py
@@ -13,6 +13,19 @@ from .party_config import party_config
 
 
 class Party:
+    """Artifactory API interface.
+
+    Attributes:
+        artifactory_url (str): Artifactory Instance API URL, e.g.
+            http://instance.jfrog.io/instance/api.
+        headers (dict): Custom request headers.
+        password (str): Authentication password base64 encoded.
+        search_name (str): Artifact search endpoint (default: search/artifact).
+        search_prop (str): Property search endpoint (default: search/prop).
+        search_repos (str): Repositories list endpoint (default: repositories).
+        username (str): Authentication username.
+
+    """
 
     def __init__(self, config={}):
         self.files = []


### PR DESCRIPTION
It would be good to document what attributes are being store in the Class. This is also an example of Google Style docstrings, https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google. I find this style to be less burdensome and more readable when looking at code and using `pydoc`. `pydocstyle` is a nice package I use to help lint and enforce some consistency.

I also chose this format because the current docstrings do not follow a standard Python style that I can find. I think the existing docstrings are following javadoc style?