### PR TITLE
feat: Find artifacts using AQL

### DIFF
--- a/party/party.py
+++ b/party/party.py
@@ -47,6 +47,9 @@ class Party:
         if query_type == "post":
             response = requests.post(query, auth=auth, headers=self.headers, **kwargs)
 
+        self.log.debug('Artifactory response: [%d] %s', response.status_code,
+                       response.text)
+
         if not response.ok:
             return None
 

--- a/party/party.py
+++ b/party/party.py
@@ -9,10 +9,13 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
+from .party_aql import find_by_aql
 from .party_config import party_config
 
 
 class Party:
+
+    find_by_aql = find_by_aql
 
     def __init__(self, config={}):
         self.files = []

--- a/party/party.py
+++ b/party/party.py
@@ -23,11 +23,12 @@ class Party:
         for k, v in party_config.items():
             setattr(self, '%s' % (k,), v)
 
-    def query_artifactory(self, query, query_type='get'):
+    def query_artifactory(self, query, query_type='get', **kwargs):
         """
         Send request to Artifactory API endpoint.
         @param: query - Required. The URL (including endpoint) to send to the Artifactory API
         @param: query_type - Optional. CRUD method. Defaults to 'get'.
+        @param: **kwargs - Extra keyword arguments to pass to :cls:`requests.models.Request`.
         """
 
         auth = (self.username, base64.b64decode(self.password).decode())
@@ -38,7 +39,7 @@ class Party:
         elif query_type == "put":
             response = requests.put(query, data=query.split('?', 1)[1], auth=auth, headers=self.headers)
         if query_type == "post":
-            pass
+            response = requests.post(query, auth=auth, headers=self.headers, **kwargs)
 
         if not response.ok:
             return None

--- a/party/party.py
+++ b/party/party.py
@@ -1,3 +1,4 @@
+import logging
 import json
 import requests
 import urllib
@@ -18,6 +19,8 @@ class Party:
     find_by_aql = find_by_aql
 
     def __init__(self, config={}):
+        self.log = logging.getLogger(__name__)
+
         self.files = []
 
         party_config.update(config)

--- a/party/party_aql.py
+++ b/party/party_aql.py
@@ -1,0 +1,28 @@
+"""Interface for AQL searches."""
+import logging
+
+from .aql import Aql
+
+LOG = logging.getLogger(__name__)
+
+
+def find_by_aql(self, **kwargs):
+    """Find artifacts using AQL.
+
+    Args:
+        **kwargs: See :class:`party.aql.Aql` for arguments.
+
+    Returns:
+        object: Results from AQL search.
+
+    """
+    aql = Aql(**kwargs)
+
+    url = '/'.join([self.artifactory_url, 'search/aql'])
+
+    old_content_type = self.headers['Content-type']
+    self.headers['Content-type'] = 'text/plain'
+    results = self.query_artifactory(url, data=aql.aql, query_type='post')
+    self.headers['Content-type'] = old_content_type
+
+    return results.json()


### PR DESCRIPTION
This mainly relies on the AQL construction in #11. We have to send the search using a POST method, so I implemented `requests.post()` and added a passthrough for unused keyword arguments. This way, the logic for managing the extra arguments can be handled in the calling method.