### PR TITLE
feat: Separate request methods in metaclass

### DIFF
--- a/party/party.py
+++ b/party/party.py
@@ -12,9 +12,10 @@ except ImportError:
 
 from .party_aql import find_by_aql
 from .party_config import party_config
+from .party_request import PartyRequest
 
 
-class Party:
+class Party(PartyRequest):
     """Artifactory API interface.
 
     Attributes:
@@ -31,7 +32,9 @@ class Party:
 
     find_by_aql = find_by_aql
 
-    def __init__(self, config={}):
+    def __init__(self, config={}, *args, **kwargs):
+        super(Party, self).__init__(*args, **kwargs)
+
         self.log = logging.getLogger(__name__)
 
         self.files = []
@@ -40,7 +43,9 @@ class Party:
 
         # Set instance variables for every value in party_config
         for k, v in party_config.items():
-            setattr(self, '%s' % (k,), v)
+            existing_attribute = getattr(self, k, None)
+            if not existing_attribute:
+                setattr(self, '%s' % (k,), v)
 
     def query_artifactory(self, query, query_type='get', **kwargs):
         """

--- a/party/party_request.py
+++ b/party/party_request.py
@@ -1,0 +1,123 @@
+"""Request interface for Artifactory."""
+import base64
+import logging
+
+import requests
+
+
+class PartyRequest(object):
+    """Request interface for Artifactory.
+
+    Args:
+        artifactory_url (str): Artifactory Instance API URL, e.g.
+            http://instance.jfrog.io/instance/api.
+        headers (dict): Custom request headers.
+        password (str): Authentication password base64 encoded.
+        username (str): Authentication username.
+
+    """
+
+    def __init__(self,
+                 artifactory_url='',
+                 headers=None,
+                 password='',
+                 username=''):
+        self.log = logging.getLogger(__name__)
+
+        self.artifactory_url = artifactory_url
+        self.password = password
+        self.username = username
+
+        self.headers = headers
+
+    def request(self, endpoint, method='get', **kwargs):
+        """Send request to Artifactory API.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+            method (str): HTTP method to use, e.g. delete, get, head, options,
+                patch, post.
+
+        Returns:
+            requests.models.Response: Artifactory response.
+
+        Raises:
+            requests.exceptions.HTTPError: Artifactory did not respond with a
+                good status.
+
+        """
+        url = '/'.join([self.artifactory_url, endpoint])
+
+        request_method = getattr(requests, method.lower())
+
+        auth = (self.username, base64.b64decode(self.password).decode())
+        response = request_method(
+            url, auth=auth, headers=self.headers, **kwargs)
+
+        self.log.debug('Artifactory response: [%d] %s', response.status_code,
+                       response.text)
+
+        response.raise_for_status()
+
+        return response
+
+    def delete(self, endpoint, **kwargs):
+        """DELETE request to Artifactory API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+
+        """
+        return self.request(endpoint, method='delete', **kwargs)
+
+    def get(self, endpoint, **kwargs):
+        """GET request to Artifactory API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+
+        """
+        return self.request(endpoint, method='get', **kwargs)
+
+    def head(self, endpoint, **kwargs):
+        """HEAD request to Artifactory API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+
+        """
+        return self.request(endpoint, method='head', **kwargs)
+
+    def options(self, endpoint, **kwargs):
+        """OPTIONS request to Artifactory API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+
+        """
+        return self.request(endpoint, method='options', **kwargs)
+
+    def patch(self, endpoint, **kwargs):
+        """PATCH request to Artifactory API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+
+        """
+        return self.request(endpoint, method='patch', **kwargs)
+
+    def post(self, endpoint, **kwargs):
+        """POST request to Artifactory API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to use, usually everything after
+                ``api/``.
+
+        """
+        return self.request(endpoint, method='post', **kwargs)


### PR DESCRIPTION
It can be nice to separate logic into different classes so one class layer can handle all of the same functionality. This is an example implementation to replace `party.party.Party.query_artifactory()` with separate methods that feels more like using `requests` directly.