### PR TITLE
feat: Default query type catch

### DIFF
--- a/party/exceptions.py
+++ b/party/exceptions.py
@@ -1,0 +1,9 @@
+"""Party exceptions."""
+
+
+class PartyError(Exception):
+    """Party base exception."""
+
+
+class UnknownQueryType(PartyError):
+    """Query type is not supported."""

--- a/party/party.py
+++ b/party/party.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
+from .exceptions import UnknownQueryType
 from .party_aql import find_by_aql
 from .party_config import party_config
 
@@ -57,8 +58,10 @@ class Party:
             response = requests.get(query, auth=auth, headers=self.headers)
         elif query_type == "put":
             response = requests.put(query, data=query.split('?', 1)[1], auth=auth, headers=self.headers)
-        if query_type == "post":
+        elif query_type == "post":
             response = requests.post(query, auth=auth, headers=self.headers, **kwargs)
+        else:
+            raise UnknownQueryType('Unsupported query type: %s' % query_type)
 
         self.log.debug('Artifactory response: [%d] %s', response.status_code,
                        response.text)


### PR DESCRIPTION
It is convenient to raise an error when an unknown HTTP method is being used.